### PR TITLE
Use Appveyor for testing on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,74 @@
+version: 1.0.{build}
+
+image: Visual Studio 2017
+
+environment:
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+    # The list here is complete (excluding Python 2.6, which
+    # isn't covered by this document) at the time of writing.
+
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
+ 
+init:
+  - echo "%PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+
+install:
+  # Install dependencies
+  - cinst ghostscript imagemagick
+  # Not sure why imagemagick doesn't seem to be appearing on path automatically. TODO: Fix this hack
+  - ps: $env:Path += ";${env:ProgramFiles}\ImageMagick-7.0.7-Q16\"
+  # Install tesseract 3.05
+  - ps: $exePath = "$env:TEMP\tesseract-ocr.exe"
+  - ps: appveyor DownloadFile https://digi.bib.uni-mannheim.de/tesseract/tesseract-ocr-setup-3.05.01.exe -FileName $exePath
+  - ps: cmd /c start /wait $exePath /S
+  # Install poppler
+  - ps: $zipPath = "$env:TEMP\poppler.7z"
+  - ps: appveyor DownloadFile http://blog.alivate.com.au/wp-content/uploads/2017/01/poppler-0.51_x86.7z -FileName $zipPath
+  - ps: $binPath = "${env:ProgramFiles(x86)}\Poppler\"
+  - ps: 7z e $zipPath "-o$binPath"
+  - ps: $env:Path += ";${binPath}"
+  # Install python dependencies
+  - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+  - "%PYTHON%\\python.exe -m pip install pytest mock pytest-catchlog"
+  - "%PYTHON%\\python.exe -m pip install ."
+
+
+build: off
+
+test_script:
+  - ps: echo $env:Path
+#  - ps: cmd pdfimages -v
+#  - ps: cmd magick -version
+  # Put your test command here.
+  # If you don't need to build C extensions on 64-bit Python 3.3 or 3.4,
+  # you can remove "build.cmd" from the front of the command, as it's
+  # only needed to support those cases.
+  # Note that you must use the environment variable %PYTHON% to refer to
+  # the interpreter you're using - Appveyor does not do anything special
+  # to put the Python version you want to use on PATH.
+  - "%PYTHON%\\python.exe setup.py test"
+
+# after_test:
+  # This step builds your wheels.
+  # Again, you only need build.cmd if you're building C extensions for
+  # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
+  # interpreter
+  # - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+
+# artifacts:
+  # bdist_wheel puts your built wheel in the dist directory
+  # - path: dist\*
+
+#on_success:
+#  You can use this step to upload your artifacts to a public website.
+#  See Appveyor's documentation for more details. Or you can simply
+#  access your wheels from the Appveyor "artifacts" tab for your build.

--- a/pypdfocr/pypdfocr_gs.py
+++ b/pypdfocr/pypdfocr_gs.py
@@ -151,7 +151,11 @@ class PyGs(object):
         self.greyscale = greyscale
 
         # Now, run imagemagick identify to get pdf width/height/density
-        cmd = 'identify -format "%%w %%x %%h %%y\n" "%s"' % pdf_filename
+
+        if os.name == 'nt':
+            cmd = 'magick identify -format "%%w %%x %%h %%y\\n" "%s"' % pdf_filename
+        else:
+            cmd = 'identify -format "%%w %%x %%h %%y\n" "%s"' % pdf_filename
         try:
             out = subprocess.check_output(
                 cmd, shell=True, universal_newlines=True)

--- a/pypdfocr/pypdfocr_preprocess.py
+++ b/pypdfocr/pypdfocr_preprocess.py
@@ -93,6 +93,8 @@ class PyPreprocess(object):
             # vertical lines in a table)
             '"%s"' % (out_filename)
             ]
+        if str(os.name) == 'nt':
+            cmd_list = ['magick'] + cmd_list
         logging.info("Preprocessing image %s for better OCR", in_filename)
         res = self.cmd(cmd_list)
         if res is None:
@@ -117,4 +119,5 @@ class PyPreprocess(object):
             pool.join()
 
         logging.info("Completed preprocessing")
+        logging.debug("Output filenames: %s", preprocessed_filenames)
         return preprocessed_filenames

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,8 @@ class PyTest(Command):
     def finalize_options(self):
         pass
     def run(self):
-        import sys,subprocess
-        cwd = os.getcwd()
-        os.chdir('test')
-        errno = subprocess.call([sys.executable, 'runtests.py'])
-        os.chdir(cwd)
+        import sys, subprocess
+        errno = subprocess.call([sys.executable, '-m', 'pytest', 'test', '--verbose'])
         raise SystemExit(errno)
 
 def read(*filenames, **kwargs):

--- a/test/test_gs.py
+++ b/test/test_gs.py
@@ -27,7 +27,7 @@ class TestGS:
     @pytest.mark.skipif(os.name != 'nt', reason="Not on NT")
     @patch('os.name')
     @patch('subprocess.call')
-    def test_gs_run_nt(self, mock_subprocess, mock_os_name, capsys):
+    def test_gs_run_nt(self, mock_subprocess, mock_os_name, caplog):
         """
             Stupid test because Windows Tesseract only returns 3.02 instead
             of 3.02.02
@@ -40,8 +40,7 @@ class TestGS:
         with pytest.raises(SystemExit):
             p._run_gs("", "", "")
 
-        out, err = capsys.readouterr()
-        assert p.msgs['GS_FAILED'] in out
+        assert p.msgs['GS_FAILED'] in caplog.text
 
     @pytest.fixture
     def pygs(self):

--- a/test/test_preprocessing.py
+++ b/test/test_preprocessing.py
@@ -45,7 +45,7 @@ def test_infile_missing(pypre):
 def test_keyboard_interrupt(pypre, monkeypatch, caplog):
     """Exceptions should be logged and re-raised"""
     monkeypatch.setattr(
-        'subprocess.check_output',
+        pypre, 'cmd',
         mock.Mock(side_effect=Exception("Boom!")))
     with pytest.raises(Exception):
         pypre.preprocess(['foo.jpg'])

--- a/test/test_pypdfocr.py
+++ b/test/test_pypdfocr.py
@@ -123,15 +123,18 @@ class TestPydfocr:
         infile = os.path.join(asset_dir, test_spec.filename)
         conffile = tmpdir.join("test.conf")
         conffile.write("""
-            target_folder: "{dirpath}/target"
-            default_folder: "{dirpath}/target/default"
+            target_folder: '{target_folder}'
+            default_folder: '{default_folder}'
 
             folders:
                 recipe:
                     - recipes
                 patents:
                     - patent
-            """.format(dirpath=str(tmpdir)))
+            """.format(
+                target_folder=os.path.join(str(tmpdir), 'target'),
+                default_folder=os.path.join(str(tmpdir), 'target', 'default')))
+
         opts = [infile, '--skip-preprocess', "--config", str(conffile), "-f"]
         pdfocr.go(opts)
 
@@ -152,16 +155,19 @@ class TestPydfocr:
         infile = os.path.join(asset_dir, test_spec.filename)
         conffile = tmpdir.join("test.conf")
         conffile.write("""
-            target_folder: "{dirpath}/target"
-            default_folder: "{dirpath}/target/default"
-            original_move_folder: "{dirpath}/original"
+            target_folder: '{target_folder}'
+            default_folder: '{default_folder}'
+            original_move_folder: '{original_folder}'
 
             folders:
                 recipe:
                     - recipes
                 patents:
                     - patent
-            """.format(dirpath=str(tmpdir)))
+            """.format(
+                target_folder=os.path.join(str(tmpdir), 'target'),
+                default_folder=os.path.join(str(tmpdir), 'target', 'default'),
+                original_folder=os.path.join(str(tmpdir), 'original')))
 
         opts = [infile, "--config", str(conffile), "-f"]
         pdfocr.go(opts)

--- a/test/test_tesseract.py
+++ b/test/test_tesseract.py
@@ -104,9 +104,7 @@ class TestTesseract:
         pyts = pypdfocr_tesseract.PyTesseract({})
         pyts._ts_version = "4.01"
         assert 'tesseract.exe' in pyts.binary
-
-        mock_os_path_exists.return_value = True
-        mock_uptodate.return_value = (True, "")
+        
         # force a bad tesseract on windows
         pyts.binary = "blah"
         with pytest.raises(SystemExit):


### PR DESCRIPTION
For better cross-platform support, CI tests should be done on Windows as well as Linux. Whilst Travis doesn't support Windows testing, appveyor.com is a similar service that only does Windows testing.

A couple of code changes were necessary for tests to pass on Windows (showing the usefulness of doing this!)

Also note that installing dependencies on appveyor isn't quite ideal at the moment, I'd like to get them all packaged on chocolatey and installing properly from there, but for now this works.