### PR TITLE
Switch to using packaging.version instead of pkg_resources.parse_version

### DIFF
--- a/pypdfocr/pypdfocr_tesseract.py
+++ b/pypdfocr/pypdfocr_tesseract.py
@@ -25,7 +25,7 @@ import subprocess
 import sys
 
 from multiprocessing import Pool
-from pkg_resources import parse_version
+from packaging import version
 from .pypdfocr_interrupts import init_worker
 
 
@@ -115,7 +115,7 @@ class PyTesseract(object):
 
     def assert_version(self):
         """Raise an exception if the tesseract version is too old."""
-        if parse_version(self.required) > parse_version(self.ts_version):
+        if version.parse(self.required) > version.parse(self.ts_version):
             raise TesseractException(
                 "Tesseract version too old. Required {} Found {}".format(
                 self.required, self.ts_version))
@@ -157,7 +157,7 @@ class PyTesseract(object):
     def make_hocr_from_pnm(self, img_filename):
         """Run OCR on single file."""
         basename = os.path.splitext(img_filename)[0]
-        if parse_version(self.ts_version) < parse_version("3.03"):
+        if version.parse(self.ts_version) < version.parse("3.03"):
             # Output format is html for old versions of tesseract
             hocr_filename = "%s.html" % basename
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ pillow>=2.2
 reportlab>=2.7
 watchdog>=0.6.0
 pypdf2>=1.23
+packaging
 evernote; python_version < '3'

--- a/test/test_tesseract.py
+++ b/test/test_tesseract.py
@@ -98,6 +98,12 @@ class TestTesseract:
         pyts = pypdfocr_tesseract.PyTesseract({})
         pyts.assert_version()
 
+    def test_tesseract_4alpha(self, monkeypatch, tmpdir):
+        monkeypatch.setattr('subprocess.check_output',
+                            mock.Mock(return_value="tesseract 4.00.00alpha"))
+        pyts = pypdfocr_tesseract.PyTesseract({})
+        pyts.assert_version()
+
     def test_force_Nt(self, monkeypatch, tmpdir):
         monkeypatch.setattr('os.name', 'nt')
         monkeypatch.setattr('os.path.exists', mock.Mock(return_value=True))


### PR DESCRIPTION
This is slightly arbitrary as both seem to work equally well, however as both
are external it makes sense to go with packaging as being a smaller and more
specific package rather than pulling pkg_resources out of setuptools.
Setuptools was also not listed as a specific dependency before, which was
bad.

Also a unit-test was added to ensure compatability with the new tesseract
`4.00.00alpha` version number added. The actual tesseract 4 binary has
not been tested for compatability.