### PR TITLE
Add unit tests for pypdfocr_filer

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,13 @@
 [report]
+
+show_missing = True
+
 exclude_lines = 
 
     pragma: no cover
     if __name__ == '__main__':
     def error(text):
+    def __repr__
+    if self\.degub
+    raise AssertionError
+    raise NotImplementedError

--- a/pypdfocr/pypdfocr_filer.py
+++ b/pypdfocr/pypdfocr_filer.py
@@ -35,9 +35,10 @@ class PyFiler(object):
     @abc.abstractmethod
     def move_to_matching_folder(self, filename, **kwargs):
         """ Move the file given by filename to the proper location.
-            You will need to use :py:attr:`target_folder` and :py:attr:`folder_targets`
-            to figure out what the proper destination is.  If there is no matching location,
-            then use :py:attr:`default_folder`
+            You will need to use :py:attr:`target_folder` and
+            :py:attr:`folder_targets` to figure out what the proper
+            destination is.  If there is no matching location, then use
+            :py:attr:`default_folder`.
 
             :param filename: File to move
             :type filename: string
@@ -52,7 +53,8 @@ class PyFiler(object):
 
             :param original_filename: File to move
             :type original_filename: string
-            :returns: Full path+filename of destination(original_filename if not moved)
+            :returns: Full path+filename of destination(original_filename if
+               not moved)
             :rtype: string
         """
 

--- a/test/test_filer.py
+++ b/test/test_filer.py
@@ -1,6 +1,16 @@
 import os
+import sys
+
+import pytest
 
 from pypdfocr import pypdfocr_filer
+
+
+if sys.version_info.major == 2:
+    @pytest.fixture(autouse=True)
+    def inst_pyfiler(monkeypatch):
+        monkeypatch.setattr(
+            pypdfocr_filer.PyFiler, "__abstractmethods__", set())
 
 
 def test_class_methods():
@@ -33,8 +43,8 @@ def test_split_filename():
 
 def test_get_filename(tmpdir):
     pf = pypdfocr_filer.PyFiler()
-    fpath = tmpdir.join("file.ext")
-    newpath = pf._get_unique_filename_by_appending_version_integer(str(fpath))
+    fpath = str(tmpdir.join("file.ext"))
+    newpath = pf._get_unique_filename_by_appending_version_integer(fpath)
     assert newpath == fpath
 
 
@@ -44,11 +54,11 @@ def test_get_filename_conflict(tmpdir):
     fpath.write("foobar")
     newpath = pf._get_unique_filename_by_appending_version_integer(str(fpath))
     assert newpath != fpath
-    assert os.path.split(newpath)[0] == os.path.split(fpath)[0]
-    assert os.path.splitext(newpath)[1] == os.path.splitext(fpath)[1]
+    assert os.path.split(newpath)[0] == os.path.split(str(fpath))[0]
+    assert os.path.splitext(newpath)[1] == os.path.splitext(str(fpath))[1]
 
 
-def test_get_filename_conflict2(tmpdir):
+def test_get_filename_conflict2(monkeypatch, tmpdir):
     pf = pypdfocr_filer.PyFiler()
     fnames = ["file.ext", "file_1.ext", "file_2.ext"]
     fpaths = [tmpdir.join(fname) for fname in fnames]
@@ -57,5 +67,5 @@ def test_get_filename_conflict2(tmpdir):
     newpath = pf._get_unique_filename_by_appending_version_integer(
         str(fpaths[0]))
     assert newpath not in fpaths
-    assert os.path.split(newpath)[0] == os.path.split(fpath)[0]
-    assert os.path.splitext(newpath)[1] == os.path.splitext(fpath)[1]
+    assert os.path.split(newpath)[0] == os.path.split(str(fpaths[0]))[0]
+    assert os.path.splitext(newpath)[1] == os.path.splitext(str(fpaths[0]))[1]

--- a/test/test_filer.py
+++ b/test/test_filer.py
@@ -1,0 +1,61 @@
+import os
+
+from pypdfocr import pypdfocr_filer
+
+
+def test_class_methods():
+    pf = pypdfocr_filer.PyFiler()
+
+    assert not pf.target_folder
+    pf.target_folder = "Target"
+    assert pf.target_folder == "Target"
+
+    assert not pf.default_folder
+    pf.default_folder = "Default"
+    assert pf.default_folder == "Default"
+
+    assert not pf.original_move_folder
+    pf.original_move_folder = "Original"
+    assert pf.original_move_folder == "Original"
+
+    assert not pf.folder_targets
+    pf.folder_targets = "Targets"
+    assert pf.folder_targets == "Targets"
+
+
+def test_split_filename():
+    path, name, ext = pypdfocr_filer.PyFiler._split_filename_dir_filename_ext(
+        "/home/user/Documents/foobar.ext")
+    assert path == "/home/user/Documents"
+    assert name == "foobar"
+    assert ext == ".ext"
+
+
+def test_get_filename(tmpdir):
+    pf = pypdfocr_filer.PyFiler()
+    fpath = tmpdir.join("file.ext")
+    newpath = pf._get_unique_filename_by_appending_version_integer(str(fpath))
+    assert newpath == fpath
+
+
+def test_get_filename_conflict(tmpdir):
+    pf = pypdfocr_filer.PyFiler()
+    fpath = tmpdir.join("file.ext")
+    fpath.write("foobar")
+    newpath = pf._get_unique_filename_by_appending_version_integer(str(fpath))
+    assert newpath != fpath
+    assert os.path.split(newpath)[0] == os.path.split(fpath)[0]
+    assert os.path.splitext(newpath)[1] == os.path.splitext(fpath)[1]
+
+
+def test_get_filename_conflict2(tmpdir):
+    pf = pypdfocr_filer.PyFiler()
+    fnames = ["file.ext", "file_1.ext", "file_2.ext"]
+    fpaths = [tmpdir.join(fname) for fname in fnames]
+    for fpath in fpaths:
+        fpath.write("foobar")
+    newpath = pf._get_unique_filename_by_appending_version_integer(
+        str(fpaths[0]))
+    assert newpath not in fpaths
+    assert os.path.split(newpath)[0] == os.path.split(fpath)[0]
+    assert os.path.splitext(newpath)[1] == os.path.splitext(fpath)[1]


### PR DESCRIPTION
Add unit-tests for filer base class, providing 100% test coverage.
Also refactor for flake8 compliance.