### PR TITLE
Add OSX testing via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
+os:
+  - linux
+  - osx
+
 language: python
 python:
     - "2.7"
     - "3.5"
     - "3.6"
 before_install:
-    - sudo apt-get -qq update
-    - sudo apt-get install -y tesseract-ocr ghostscript imagemagick poppler-utils
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install tesseract ghostscript poppler imagemagick; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y tesseract-ocr ghostscript imagemagick poppler-utils; fi
 install: 
     - "pip install -r requirements.txt"
-    - "pip install pytest mock pytest-catchlog"
+    - "pip install pytest mock"
     - "pip install ."
 script: 
     - "pytest test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,39 @@
-os:
-  - linux
-  - osx
-
 language: python
-python:
-    - "2.7"
-    - "3.5"
-    - "3.6"
+
+matrix:
+    include:
+        - os: linux
+          sudo: required
+          python: 2.7
+          env: PYVER=2.7
+        - os: linux
+          sudo: required
+          python: 3.5
+          env: PYVER=3.5
+        - os: linux
+          sudo: required
+          python: 3.6
+          env: PYVER=3.6
+        - os: osx
+          language: generic
+          env: PYVER=2.7
+        - os: osx
+          language: generic
+          env: PYVER=3.5
+        - os: osx
+          language: generic
+          env: PYVER=3.6
+
+
 before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install tesseract ghostscript poppler imagemagick; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y tesseract-ocr ghostscript imagemagick poppler-utils; fi
+    - ./.travis_install.sh
 install: 
-    - "pip install -r requirements.txt"
-    - "pip install pytest mock"
-    - "pip install ."
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export PATH="$HOME/miniconda/bin:$PATH"; fi;
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then source activate test_env; fi;
+    - pip install -r requirements.txt
+    - pip install pytest mock
+    - pip install .
 script: 
-    - "pytest test"
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export PATH="$HOME/miniconda/bin:$PATH"; fi;
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then source activate test_env; fi;
+    - pytest test

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ev # exit on first error, print each command
+
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+
+    # Install requirements on OS X
+    brew update || brew update
+
+    brew install tesseract ghostscript poppler imagemagick
+
+    wget http://repo.continuum.io/miniconda/Miniconda3-3.7.0-MacOSX-x86_64.sh -O ~/miniconda.sh
+
+    bash ~/miniconda.sh -b -p $HOME/miniconda
+    export PATH="$HOME/miniconda/bin:$PATH"
+
+    conda create --yes --name test_env python=${PYVER} pip
+else
+    # Install requirements on Linux
+    sudo apt-get -qq update
+    sudo apt-get install -y tesseract-ocr ghostscript imagemagick poppler-utils
+fi;


### PR DESCRIPTION
If we support OSX we should also test on OSX, especially as it can be done on Travis. Sadly Python isn't officially supported yet, hence why this is a bit messy, but gets the job done at least.